### PR TITLE
Option to allow install2.r to error if package installation fails

### DIFF
--- a/examples/install2.r
+++ b/examples/install2.r
@@ -6,18 +6,30 @@
 suppressMessages(library(docopt))       # we need docopt (>= 0.3) as on CRAN
 
 ## configuration for docopt
-doc <- "Usage: install.r [-r REPO] [-l LIBLOC] [-h] [-d DEPS] [PACKAGES ...]
+doc <- "Usage: install.r [-r REPO] [-l LIBLOC] [-h] [-d DEPS] [-e ERROR] [PACKAGES ...]
 
 -r --repos REPO     repository to install from [default: http://cran.rstudio.com]
 -l --libloc LIBLOC  location in which to install [default: /usr/local/lib/R/site-library]
 -d --deps DEPS      Install suggested dependencies as well? [default: FALSE]
+-e --error ERROR    Throw error and halt if package cannot be installed? (usually a warning). [default: FALSE]
 -h --help           show this help text"
 
 ## docopt parsing
 opt <- docopt(doc)
 
 ## installation given selected options and arguments
-install.packages(pkgs  = opt$PACKAGES,
-                 lib   = opt$libloc,
-                 repos = opt$repos,
-                 dependencies=opt$deps)
+
+if(opt$error){
+  withCallingHandlers(
+  install.packages(pkgs  = opt$PACKAGES,
+                   lib   = opt$libloc,
+                   repos = opt$repos,
+                   dependencies=opt$deps),
+  warning = stop)
+
+} else { 
+  install.packages(pkgs  = opt$PACKAGES,
+                   lib   = opt$libloc,
+                   repos = opt$repos,
+                   dependencies=opt$deps)
+}


### PR DESCRIPTION
Failing package installations only throw a warning in R.  Solution treats warnings as errors.  Solution based on http://stackoverflow.com/questions/26244530 to address issue reported in  https://github.com/eddelbuettel/rocker/issues/24
