### PR TITLE
Permit multiple repos with multiple `-r` flags

### DIFF
--- a/examples/install2.r
+++ b/examples/install2.r
@@ -11,7 +11,7 @@
 suppressMessages(library(docopt))       # we need docopt (>= 0.3) as on CRAN
 
 ## configuration for docopt
-doc <- "Usage: install.r [-r REPO] [-l LIBLOC] [-h] [-d DEPS] [--error] [PACKAGES ...]
+doc <- "Usage: install.r [-r REPO...] [-l LIBLOC] [-h] [-d DEPS] [--error] [PACKAGES ...]
 
 -r --repos REPO     repository to install from [default: http://cran.rstudio.com]
 -l --libloc LIBLOC  location in which to install [default: /usr/local/lib/R/site-library]


### PR DESCRIPTION
Whoops, somehow I forgot that I never got around to this.  Here's the edit to `install2.r` to permit multiple repos, as discussed in #8 and https://github.com/docopt/docopt.R/issues/8