### PR TITLE
Install suggested packages for check

### DIFF
--- a/examples/check.r
+++ b/examples/check.r
@@ -45,7 +45,7 @@ installArg <- function(p, lib, rep) {
     install.packages(pkgs=p,
                      lib=lib,
                      repos=rep,
-                     dependencies=TRUE)
+                     dependencies=c("Depends", "Imports", "LinkingTo", "Suggests"))
 }
 
 ## if binary .deb files are to be installed first:


### PR DESCRIPTION
Unit test package dependencies (RUnit, testthat) are often listed in the
Suggested section of the package DESCRIPTION and are required for
check.R (at least in my use case).