### PR TITLE
Add ncpus argument to install2.r

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2018-12-30  Colin Gillespie  <csgillespie@gmail.com>
+
+	* inst/examples/install2.r: Add -n (Ncpus) argument
+
 2018-10-30  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/examples/install.r: Add "." if no argument given but
@@ -988,7 +992,7 @@
 	* configure.in: Added Dirk's patch to configure.in to
 	automatically find R in search path and to use --rpath linker option.
 
-	* rinterp.c: Read commands from stdin when no file is given on 
+	* rinterp.c: Read commands from stdin when no file is given on
 	cmdline. (feature request from Dirk Eddelbuettel <edd@debian.org>)
 
 2006-08-09  Jeffrey Horner  <jeffrey.horner@vanderbilt.edu>

--- a/inst/examples/install2.r
+++ b/inst/examples/install2.r
@@ -12,16 +12,16 @@
 library(docopt)
 
 ## configuration for docopt
-doc <- "Usage: install2.r [-r REPO...] [-l LIBLOC] [-h] [-x] [-s] [-d DEPS] [--error] [--] [PACKAGES ...]
+doc <- "Usage: install2.r [-r REPO...] [-l LIBLOC] [-h] [-x] [-s] [-d DEPS] [-n NCPUS] [--error] [--] [PACKAGES ...]
 
 -r --repos REPO     repository to use, or NULL for file [default: getOption]
 -l --libloc LIBLOC  location in which to install [default: /usr/local/lib/R/site-library]
 -d --deps DEPS      install suggested dependencies as well [default: NA]
+-n --ncpus NCPUS    number of parallel processes to use for a parallel install [default: getOption]
 -e --error          throw error and halt instead of a warning [default: FALSE]
 -s --skipinstalled  skip installing already installed packages [default: FALSE]
 -h --help           show this help text
 -x --usage          show help and short example usage"
-
 opt <- docopt(doc)			# docopt parsing
 
 if (opt$usage) {
@@ -32,10 +32,12 @@ arguments understood by R CMD INSTALL can be passed interspersed in the PACKAGES
 this requires use of '--'.
 
 Examples:
-  install2.r -l /tmp/lib Rcpp BH                         # install into given library
-  install2.r -- --with-keep.source drat                  # keep the source
-  install2.r -- --data-compress=bzip2 stringdist         # prefer bz2 compression
-  install2.r \".\"                                         # install package in current directory
+  install2.r -l /tmp/lib Rcpp BH                    # install into given library
+  install2.r -- --with-keep.source drat             # keep the source
+  install2.r -- --data-compress=bzip2 stringdist    # prefer bz2 compression
+  install2.r \".\"                                  # install package in current directory
+  install2.r --n  6 Rcpp                            # parallel install: (6 processes)
+  install2.r --n -1 Rcpp                 # parallel install: max(1, parallel::detectCores)
 
 install2.r is part of littler which brings 'r' to the command-line.
 See http://dirk.eddelbuettel.com/code/littler.html for more information.\n")
@@ -50,10 +52,17 @@ if (opt$deps == "TRUE" || opt$deps == "FALSE") {
 
 ## docopt results are characters, so if we meant NULL we have to set NULL
 if (opt$repos == "NULL")  {
-    opt$repos = NULL
+    opt$repos <- NULL
 } else if (opt$repos == "getOption") {
     ## as littler can now read ~/.littler.r and/or /etc/littler.r we can preset elsewhere
-    opt$repos = getOption("repos")
+    opt$repos <- getOption("repos")
+}
+
+if (opt$ncpus == "getOption") {
+  opt$ncpus <- getOption("Ncpus", 1L)
+} else if (opt$ncpus == "-1") {
+  # parallel comes with R 2.14+
+  opt$ncpus <- max(1L, parallel::detectCores())
 }
 
 install_packages2 <- function(pkgs, ..., error = FALSE, skipinstalled = FALSE) {
@@ -83,12 +92,13 @@ install_packages2 <- function(pkgs, ..., error = FALSE, skipinstalled = FALSE) {
 isMatchingFile <- function(f) (file.exists(f) && grepl("(\\.tar\\.gz|\\.tgz|\\.zip)$", f)) || (f == ".")
 
 ## helper function which switches to local (ie NULL) repo if matching file is presented
-installArg <- function(f, lib, rep, dep, iopts, error, skipinstalled) {
+installArg <- function(f, lib, rep, dep, iopts, error, skipinstalled, ncpus) {
     install_packages2(pkgs=f,
                       lib=lib,
                       repos=if (isMatchingFile(f)) NULL else rep,
                       dependencies=dep,
                       INSTALL_opts=iopts,
+                      Ncpus = ncpus,
                       error = error,
                       skipinstalled = skipinstalled)
 }
@@ -105,7 +115,7 @@ if (length(opt$PACKAGES)==0 && file.exists("DESCRIPTION") && file.exists("NAMESP
 }
 
 sapply(opt$PACKAGES, installArg, opt$libloc, opt$repos, opt$deps,
-       installOpts, opt$error, opt$skipinstalled)
+       installOpts, opt$error, opt$skipinstalled, opt$ncpus)
 
 ## clean up any temp file containing CRAN directory information
 sapply(list.files(path=tempdir(), pattern="^(repos|libloc).*\\.rds$", full.names=TRUE), unlink)


### PR DESCRIPTION
 * Added ncpus argument to install2.r: `-n` and `-ncpus`
 * Default: ` getOption("Ncpus", 1L)`
 * `-n -1`: `max(1L, parallel::detectCores())`
  * Parallel package has been around since R 2.14
 * Changed some rogue assignment operators from `=` to `<-`
 * Updated changelog

---
Closes #62 