### PR TITLE
Improve error detection on failed download

### DIFF
--- a/inst/examples/install2.r
+++ b/inst/examples/install2.r
@@ -77,7 +77,7 @@ install_packages2 <- function(pkgs, ..., error = FALSE, skipinstalled = FALSE) {
         if (error) {
             catch <-
                 grepl("download of package .* failed", e$message) ||
-                grepl("package.*(is|are) not available", e$message) ||
+                grepl("(dependenc|package).*(is|are) not available", e$message) ||
                 grepl("installation of package.*had non-zero exit status", e$message)
             if (catch) {
                 e <<- e

--- a/inst/examples/install2.r
+++ b/inst/examples/install2.r
@@ -76,6 +76,7 @@ install_packages2 <- function(pkgs, ..., error = FALSE, skipinstalled = FALSE) {
     capture <- function(e) {
         if (error) {
             catch <-
+                grepl("download of package .* failed", e$message) ||
                 grepl("package.*(is|are) not available", e$message) ||
                 grepl("installation of package.*had non-zero exit status", e$message)
             if (catch) {


### PR DESCRIPTION
When a package can't be downloaded, a warning appears:

    Warning in download.packages(pkgs, destdir = tmpd, available = available,  :
      download of package ‘vcd’ failed

The package is not installed, but install2.r returns successfully even though
we use `--error`.

This commit captures that warning so the error can be captured and returned.

One way to simulate this error is by making `/tmp/downloaded_packages` not writeable.