### PR TITLE
add RSPM code detection for CentOS/RHEL/Fedora

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-09-20  Iñaki Úcar  <iucar@fedoraproject.org>
+
+	* inst/examples/installRSPM.r: Add RH/CentOS/Fedora support
+
 2020-09-20  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .travis.yml (install): Switch to BSPM use for Travis

--- a/inst/examples/installRSPM.r
+++ b/inst/examples/installRSPM.r
@@ -20,9 +20,8 @@ if (file.exists("/etc/os-release")) {   # next block borrowed from my chshli pac
     osrel <- read.table("/etc/os-release", sep="=", row.names=1, col.names=c("key","value"))
     if ("REDHAT_SUPPORT_PRODUCT" %in% rownames(osrel)) {
         # 'centos7' for CentOS/RHEL 7, 'centos8' for CentOS/RHEL 8 and Fedora
-        ver <- if (osrel["REDHAT_SUPPORT_PRODUCT", "value"] == "Fedora")
-            8 else osrel["REDHAT_SUPPORT_PRODUCT_VERSION", "value"]
-        code <- paste0("centos", ver)
+        ver <- osrel["REDHAT_SUPPORT_PRODUCT_VERSION", "value"]
+        code <- paste0("centos", min(as.numeric(ver), 8))
     } else if ("VERSION_CODENAME" %in% rownames(osrel)) {
         code <- osrel["VERSION_CODENAME", "value"]
     }

--- a/inst/examples/installRSPM.r
+++ b/inst/examples/installRSPM.r
@@ -18,8 +18,14 @@ if (Sys.info()[["sysname"]] != "Linux")
 code <- "<unknown>"
 if (file.exists("/etc/os-release")) {   # next block borrowed from my chshli package on GitHub
     osrel <- read.table("/etc/os-release", sep="=", row.names=1, col.names=c("key","value"))
-    if ("VERSION_CODENAME" %in% rownames(osrel))
+    if ("REDHAT_SUPPORT_PRODUCT" %in% rownames(osrel)) {
+        # 'centos7' for CentOS/RHEL 7, 'centos8' for CentOS/RHEL 8 and Fedora
+        ver <- if (osrel["REDHAT_SUPPORT_PRODUCT", "value"] == "Fedora")
+            8 else osrel["REDHAT_SUPPORT_PRODUCT_VERSION", "value"]
+        code <- paste0("centos", ver)
+    } else if ("VERSION_CODENAME" %in% rownames(osrel)) {
         code <- osrel["VERSION_CODENAME", "value"]
+    }
 }
 if ((code == "<unknown>") && (Sys.which("lsb_release") != "")) {
     code <- system("lsb_release -c | awk '{print $2}'", intern=TRUE)


### PR DESCRIPTION
We need:

- `centos7` for CentOS 7 and RHEL 7.
- `centos8` for CentOS 8, RHEL 8 and all Fedora.