### PR TITLE
check if multiple packages fail with parallel install

### DIFF
--- a/inst/examples/install2.r
+++ b/inst/examples/install2.r
@@ -79,7 +79,8 @@ install_packages2 <- function(pkgs, ..., error = FALSE, skipinstalled = FALSE) {
             catch <-
                 grepl("download of package .* failed", e$message) ||
                 grepl("(dependenc|package).*(is|are) not available", e$message) ||
-                grepl("installation of package.*had non-zero exit status", e$message)
+                grepl("installation of package.*had non-zero exit status", e$message) ||
+                grepl("installation of one or more packages failed", e$message)
             if (catch) {
                 e <<- e
             }


### PR DESCRIPTION
When installing multiple packages with `Ncpu>1` (so in parallel) and 1+ package installs fail, then the current error check do not capture the `installation of one or more packages failed` warning of `install.pacakges`. This PR should take care of it, example run (using two packages with special SystemDependencies):

```
$ install2.r -n 2 --error OpenCL BRugs ; echo $?

trying URL 'http://mran.microsoft.com/snapshot/2020-10-01/src/contrib/OpenCL_0.2-1.tar.gz'
Content type 'application/octet-stream' length 20313 bytes (19 KB)
==================================================
downloaded 19 KB

trying URL 'http://mran.microsoft.com/snapshot/2020-10-01/src/contrib/BRugs_0.9-0.tar.gz'
Content type 'application/octet-stream' length 96430 bytes (94 KB)
==================================================
downloaded 94 KB

begin installing package ‘OpenCL’
begin installing package ‘BRugs’
make: *** [Makefile:4: OpenCL.ts] Error 1
make: *** [Makefile:9: BRugs.ts] Error 1
make: Target 'all' not remade because of errors.
* installing *source* package ‘OpenCL’ ...
** package ‘OpenCL’ successfully unpacked and MD5 sums checked
** using staged installation
** libs
make[1]: Entering directory '/tmp/RtmpxG54jS/R.INSTALLe4b3bde208f/OpenCL/src'
gcc -std=gnu99 -I"/usr/share/R/include" -DNDEBUG     -fvisibility=hidden -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-5iUtQS/r-base-4.0.2=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c buffer.c -o buffer.o
In file included from buffer.c:2:
ocl.h:7:10: fatal error: CL/opencl.h: No such file or directory
    7 | #include <CL/opencl.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
make[1]: *** [/usr/lib/R/etc/Makeconf:167: buffer.o] Error 1
make[1]: Leaving directory '/tmp/RtmpxG54jS/R.INSTALLe4b3bde208f/OpenCL/src'
ERROR: compilation failed for package ‘OpenCL’
* removing ‘/usr/local/lib/R/site-library/OpenCL’
* 
* installing *source* package ‘BRugs’ ...
** package ‘BRugs’ successfully unpacked and MD5 sums checked
** using staged installation
checking for prefix by checking for OpenBUGS... no
configure: error: OpenBUGS 3.2.2 or later not found. Install it, or specify its location using, for example, R CMD INSTALL BRugs --configure-args='--with-openbugs=/usr/local' 
ERROR: configuration failed for package ‘BRugs’
* removing ‘/usr/local/lib/R/site-library/BRugs’

The downloaded source packages are in
        ‘/tmp/downloaded_packages’
Error: installation of one or more packages failed,
  probably ‘OpenCL’, ‘BRugs’
In addition: Warning message:
In install.packages(pkgs, ...) :
  installation of one or more packages failed,
  probably ‘OpenCL’, ‘BRugs’

1
```