### PR TITLE
respect .libPaths() for install2.r default install location

### DIFF
--- a/inst/examples/install2.r
+++ b/inst/examples/install2.r
@@ -14,7 +14,7 @@ library(docopt)
 ## configuration for docopt
 doc <- "Usage: install2.r [-l LIBLOC] [-h] [-x] [-s] [-d DEPS] [-n NCPUS] [-r REPOS...] [-m METHOD] [--error] [--] [PACKAGES ...]
 
--l --libloc LIBLOC  location in which to install [default: /usr/local/lib/R/site-library]
+-l --libloc LIBLOC  location in which to install [default: NULL]
 -d --deps DEPS      install suggested dependencies as well [default: NA]
 -n --ncpus NCPUS    number of processes to use for parallel install [default: getOption]
 -r --repos REPOS    repositor(y|ies) to use, or NULL for file [default: getOption]
@@ -65,6 +65,13 @@ if (opt$ncpus == "getOption") {
 } else if (opt$ncpus == "-1") {
     ## parallel comes with R 2.14+
     opt$ncpus <- max(1L, parallel::detectCores())
+}
+
+if (opt$libloc == "NULL") {
+    ## NULL corresponds to .libPaths() but some directories may be non-writeable
+    ## so we filter out the ones where we can write and use only those
+    canWrite <- function(d) file.access(d, mode=2) == 0
+    opt$libloc <- Filter(canWrite, .libPaths())
 }
 
 ## ensure installation is stripped


### PR DESCRIPTION
Hello!

I have a question about the default install location for install2.r. Is there a reason why it's set to /usr/local/lib/R/site-library ? install.packages itself looks into .libPaths() for the default location, but with install2.r wrapping it, .libPaths() is ignored. 

I bumped into an issue where the default /usr/local/lib/R/site-library/ is actually not writable for our users, and plus I wasn't sure why install2.r tries installing somewhere different from where install.packages tries installing by default (our users use both). 

I saw how you dealt with this in update.r, and I was wondering if this would be a better approach for install2.r as well?

Thank you very much for your time!

-Lena