### PR TITLE
Add additional options to installBioc.r

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2022-08-28  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/examples/installBioc.r:
+
+2022-08-24  Pieter Moris  <pieter.moris@glpg.com>
+
+	* inst/examples/installBioc.r: Generalization, extension and extra
+	features similar to how install2.r generalizes install2.r
+
 2022-07-16  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/examples/r2u.r: Add simple r2u.r frontend

--- a/inst/examples/installBioc.r
+++ b/inst/examples/installBioc.r
@@ -9,13 +9,23 @@
 ## load docopt package from CRAN
 library(docopt)
 
-## configuration for docopt
-doc <- "Usage: installBioc.r [-l LIBLOC] [-h] [-x] [PACKAGES ...]
+## default to first library location in .libPaths()
+libloc <- .libPaths()[1]
 
--l --libloc LIBLOC  location in which to install [default: /usr/local/lib/R/site-library]
+## configuration for docopt
+doc <- paste0("Usage: installBioc.r [-l LIBLOC] [-d DEPS] [-n NCPUS] [-r REPO ...] [--error] [--skipinstalled] [-m METHOD] [--force] [--update] [-h] [-x] [PACKAGES ...]
+-l --libloc LIBLOC  location in which to install [default: ", libloc, "]
+-d --deps DEPS      install suggested dependencies as well [default: NA]
+-n --ncpus NCPUS    number of processes to use for parallel install [default: getOption]
+-r --repo REPO      additional repository to use [default: getOption]
+-e --error          throw error and halt instead of a warning [default: FALSE]
+-s --skipinstalled  skip installing already installed packages (takes priority over --force) [default: FALSE]
+-m --method METHOD  method to be used for downloading files [default: auto]
+-f --force          force re-download of packages that are currently up-to-date [default: FALSE]
+-u --update         update old already installed packages [default: FALSE]
 -h --help           show this help text
--x --usage          show help and short example usage"
-opt <- docopt(doc)			# docopt parsing
+-x --usage          show help and short example usage")
+opt <- docopt(doc)  # docopt parsing
 
 if (opt$usage) {
     cat(doc, "\n\n")
@@ -24,6 +34,8 @@ package 'BiocManger' which has be installed.
 
 Examples:
   installBioc.r -l /tmp/lib S4Vectors               # install into given library
+  installBioc.r --update Biobase                    # install package and update older packages
+  installBioc.r --deps NA --error --skipinstalled   # install package without suggested dependencies, throw an error on installation failure and skip packages that are already present
 
 installBioC.r is part of littler which brings 'r' to the command-line.
 See http://dirk.eddelbuettel.com/code/littler.html for more information.\n")
@@ -31,13 +43,84 @@ See http://dirk.eddelbuettel.com/code/littler.html for more information.\n")
 }
 
 if (!requireNamespace("BiocManager", quietly=TRUE)) {
-    stop("Please install 'BiocManager' first, for example via 'install.r BiocManager'.", call.=FALSE)
+    stop("Please install 'BiocManager' first, for example via 'install2.r BiocManager'.", call.=FALSE)
+}
+
+## set repository to empty character vector if not supplied, since
+## this is the input expected by BiocManager::install(site_repository=)
+## (does not accept NA)
+## the custom repository must be a sub-repository of a main BioC_mirror
+## e.g. software: https://bioconductor.statistik.tu-dortmund.de/packages/3.15/bioc/
+## annotation: https://ftp.gwdg.de/pub/misc/bioconductor/packages/3.14/data/annotation
+if (opt$repo == "getOption") {
+    opt$repo = character()
+}
+
+## check if dependencies need to be installed, see
+## https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/install.packages
+## the default, NA, means c("Depends", "Imports", "LinkingTo"), but not "Suggests"
+if (opt$deps == "TRUE" || opt$deps == "FALSE") {
+    opt$deps <- as.logical(opt$deps)
+} else if (opt$deps == "NA") {
+    opt$deps <- NA
+}
+
+## set the number of parallel processes to use for a parallel install of
+## more than one source package, see
+## https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/install.packages
+if (opt$ncpus == "getOption") {
+    opt$ncpus <- getOption("Ncpus", 1L)
+} else if (opt$ncpus == "-1") {
+    ## parallel comes with R 2.14+
+    opt$ncpus <- max(1L, parallel::detectCores())
+}
+
+## helper function to catch errors that could arise when package installation has failed
+## and to skip installation of packages that are already present (for BiocManager::install()
+## these would otherwise result in additional warnings)
+install_bioc <- function(pkgs, ..., error = FALSE, skipinstalled = FALSE) {
+    e <- NULL
+    capture <- function(e) {
+        if (error) {
+            catch <-
+                grepl("installation of one or more packages failed", e$message) ||
+                grepl("is not available", e$message) ||
+                grepl("had non-zero exit status", e$message) ||
+                grepl("compilation failed for package.*", e$message) ||
+                grepl("fatal error", e$message) ||
+                grepl("No such file or directory", e$message)
+            if (catch) {
+                e <<- e
+            }
+        }
+    }
+    if (skipinstalled) {
+        pkgs <- setdiff(pkgs, installed.packages()[,1])
+    }
+    if (length(pkgs) > 0) {
+        withCallingHandlers(BiocManager::install(pkgs, ...), warning = capture)
+        if (!is.null(e)) {
+            stop(e$message, call. = FALSE)
+        }
+    }
 }
 
 ## ensure installation is stripped
 Sys.setenv("_R_SHLIB_STRIP_"="true")
 
-## set .libPaths()
-.libPaths(opt$lib)
-
-BiocManager::install(opt$PACKAGES, update=FALSE, ask=FALSE)
+## install requested packages using helper function
+## ask must be set to FALSE because user prompts do not appear when calling
+## R from the CLI, e.g.
+## `R -e 'BiocManager::install("Biobase", ask=TRUE, update=TRUE)'`
+## might warn that MASS is out of date, but would not show a user prompt
+install_bioc(pkgs = opt$PACKAGES,
+        lib = opt$libloc,
+        site_repository = opt$repo,
+        update = opt$update,
+        ask = FALSE,
+        force = opt$force,
+        dependencies = opt$deps,
+        Ncpus = opt$ncpus,
+        method = opt$method,
+        error = opt$error,
+        skipinstalled = opt$skipinstalled)

--- a/inst/examples/installBioc.r
+++ b/inst/examples/installBioc.r
@@ -2,7 +2,8 @@
 #
 # Install a package from BioConductor
 #
-# Copyright (C) 2020 -       Dirk Eddelbuettel
+# Copyright (C) 2020 - 2022  Dirk Eddelbuettel
+# Copyright (C) 2022 - 2022  Dirk Eddelbuettel and Pieter Moris
 #
 # Released under GPL (>= 2)
 
@@ -35,7 +36,9 @@ package 'BiocManger' which has be installed.
 Examples:
   installBioc.r -l /tmp/lib S4Vectors               # install into given library
   installBioc.r --update Biobase                    # install package and update older packages
-  installBioc.r --deps NA --error --skipinstalled   # install package without suggested dependencies, throw an error on installation failure and skip packages that are already present
+  installBioc.r --deps NA --error --skipinstalled   # install package without suggested dependencies,
+                                                    # throw an error on installation failure and skip
+                                                    # packages that are already present
 
 installBioC.r is part of littler which brings 'r' to the command-line.
 See http://dirk.eddelbuettel.com/code/littler.html for more information.\n")
@@ -43,7 +46,7 @@ See http://dirk.eddelbuettel.com/code/littler.html for more information.\n")
 }
 
 if (!requireNamespace("BiocManager", quietly=TRUE)) {
-    stop("Please install 'BiocManager' first, for example via 'install2.r BiocManager'.", call.=FALSE)
+    stop("Please install 'BiocManager' first, for example via 'install.r BiocManager'.", call.=FALSE)
 }
 
 ## set repository to empty character vector if not supplied, since


### PR DESCRIPTION
This PR adds additional options to the installBioc.r example script based on the approach used in install2.r. 

The main goal was to be able to use the installBioc.r script as the main method to install bioconductor packages in Dockerfiles, because the standard method that is recommended by Bioconductor (`RUN R -e 'BiocManager::install("scAlign")'`, https://www.bioconductor.org/help/docker/) does not throw an error that causes the docker build process to stop. 

This can result in seemingly successfully built docker images that lack some of the packages which the creator expected to be installed. Since building docker images with r packages is so error prone (due to the need for system libraries that often just requires trial and error), this new script can make the task a lot easier. Builds will fail clearly, rather than having to scroll through the wall of text install log output or trying to manually load each package when running a container.

The script now throws errors when a package fails to install due to missing dependencies, misspelled names, etc. Already installed packages can be skipped. Suggested dependencies can be toggled. Parallel install can be enabled. Download method can be set. 

A few options were added for BiocManager::install()'s unique arguments. A toggle to update other packages that are
outdated. Additional repositories can be prepended to the standard BioC repository (only works for bioc sub-repositories
like software/experiment, see https://rdrr.io/cran/BiocManager/man/install.html). Already installed packages can be forced to redownload and install.

In addition, the library path is now set in the same manner as is done in install2.r (by reading the first entry of .libPaths() and passing it to the install function, rather than setting it to `/usr/local/lib/R/site-library` via `.libPaths()`).

This addresses some of the issues I faced myself (https://github.com/Bioconductor/bioconductor_docker/issues/38, https://github.com/Bioconductor/BiocManager/issues/124, https://github.com/eddelbuettel/littler/issues/93, https://github.com/rocker-org/rocker-versioned2/issues/292) as well as others (https://github.com/rocker-org/rocker-versioned2/issues/370).

I believe my modifications to the script could still benefit from a critical review. Especially the errors that the script now attempts to catch is somewhat guesswork. Based on my own testing, these messages are the most common ones, but perhaps I've missed some others. 