### PR TITLE
Update the pattern of warning message (in `install2.r` script)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2022-09-03  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/examples/installBioc.r (capture): Update error message pattern
+	used to detect failure to change in R 4.3.*
+
+2022-09-03  SHIMA Tatsuya  <ts1s1andn@gmail.com>
+
+	* inst/examples/install2.r (capture): Update error message pattern
+	used to detect failure to change in R 4.3.*
+
 2022-08-28  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.3.16

--- a/inst/examples/install2.r
+++ b/inst/examples/install2.r
@@ -81,7 +81,7 @@ install_packages2 <- function(pkgs, ..., error = FALSE, skipinstalled = FALSE) {
                 grepl("download of package .* failed", e$message) ||
                 grepl("(dependenc|package).*(is|are) not available", e$message) ||
                 grepl("installation of package.*had non-zero exit status", e$message) ||
-                grepl("installation of one or more packages failed", e$message)
+                grepl("installation of .+ packages failed", e$message)
             if (catch) {
                 e <<- e
             }

--- a/inst/examples/install2.r
+++ b/inst/examples/install2.r
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2011 - 2014  Dirk Eddelbuettel
 # Copyright (C) 2014 - 2017  Carl Boettiger and Dirk Eddelbuettel
-# Copyright (C) 2018 - 2022  Carl Boettiger, Dirk Eddelbuettel, and Brandon Bertelsen
+# Copyright (C) 2018 - 2022  Carl Boettiger, Dirk Eddelbuettel, Brandon Bertelsen, and SHIMA Tatsuya
 #
 # Released under GPL (>= 2)
 

--- a/inst/examples/installBioc.r
+++ b/inst/examples/installBioc.r
@@ -86,7 +86,7 @@ install_bioc <- function(pkgs, ..., error = FALSE, skipinstalled = FALSE) {
     capture <- function(e) {
         if (error) {
             catch <-
-                grepl("installation of one or more packages failed", e$message) ||
+                grepl("installation of .* packages failed", e$message) ||
                 grepl("is not available", e$message) ||
                 grepl("had non-zero exit status", e$message) ||
                 grepl("compilation failed for package.*", e$message) ||


### PR DESCRIPTION
Related to rocker-org/rocker-versioned2#529

It appears that the pattern needs to be updated to catch the warning massages with R devel (R 4.3). e.g.

```log
--------------------------- [ANTICONF] --------------------------------
Configuration failed to find the harfbuzz freetype2 fribidi library. Try installing:
 * deb: libharfbuzz-dev libfribidi-dev (Debian, Ubuntu, etc)
 * rpm: harfbuzz-devel fribidi-devel (Fedora, EPEL)
 * csw: libharfbuzz_dev libfribidi_dev (Solaris)
 * brew: harfbuzz fribidi (OSX)
If harfbuzz freetype2 fribidi is already installed, check that 'pkg-config' is in your
PATH and PKG_CONFIG_PATH contains a harfbuzz freetype2 fribidi.pc file. If pkg-config
is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:
R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
-------------------------- [ERROR MESSAGE] ---------------------------
<stdin>:1:10: fatal error: hb-ft.h: No such file or directory
compilation terminated.
--------------------------------------------------------------------
ERROR: configuration failed for package ‘textshaping’
* removing ‘/usr/local/lib/R/site-library/textshaping’
cat: ragg.out: No such file or directory
cat: pkgdown.out: No such file or directory
cat: devtools.out: No such file or directory

The downloaded source packages are in
        ‘/tmp/downloaded_packages’
Warning message:
In install.packages(pkgs, ...) : installation of 4 packages failed:
  ‘textshaping’, ‘ragg’, ‘pkgdown’, ‘devtools’
```