### PR TITLE
more error message support in install2.r

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-03-23  SHIMA Tatsuya  <ts1s1andn@gmail.com>
+
+	* inst/examples/install2.r (capture): Update error message pattern
+	used to detect failure to change in R 4.3.*
+
 2023-03-23  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/examples/install2.r (capture): Small generalisation for

--- a/inst/examples/install2.r
+++ b/inst/examples/install2.r
@@ -86,7 +86,7 @@ install_packages2 <- function(pkgs, ..., error = FALSE, skipinstalled = FALSE) {
     capture <- function(e) {
         if (error) {
             catch <-
-                grepl("download of package .* failed", e$message) ||
+                grepl("(download|installation) of package .* failed", e$message) ||
                 grepl("(dependenc|package).*(is|are) not available", e$message) ||
                 grepl("installation of package.*had non-zero exit status", e$message) ||
                 grepl("installation of .+ package(|s) failed", e$message)


### PR DESCRIPTION
From rocker-org/rocker-versioned2#620

https://github.com/rocker-org/rocker-versioned2/actions/runs/4485355667/jobs/7886817485#step:7:18245

```log
#7 2068.8 * installing *source* package ‘arrow’ ...
#7 2068.8 ** package ‘arrow’ successfully unpacked and MD5 sums checked
#7 2068.8 ** using staged installation
#7 2068.8 *** Found libcurl and openssl >= 3.0.0
#7 2068.8 Warning message:
#7 2068.8 In unzip(bin_file, exdir = dst_dir) : error 1 in extracting from zip file
#7 2068.8 ------------------------- NOTE ---------------------------
#7 2068.8 There was an issue preparing the Arrow C++ libraries.
#7 2068.8 See https://arrow.apache.org/docs/r/articles/install.html
#7 2068.8 ---------------------------------------------------------
#7 2068.8 ERROR: configuration failed for package ‘arrow’
#7 2068.8 * removing ‘/usr/local/lib/R/site-library/arrow’
#7 2068.8 
#7 2068.8 The downloaded source packages are in
#7 2068.8 	‘/tmp/downloaded_packages’
#7 2068.8 Warning message:
#7 2068.8 In install.packages(pkgs, ...) : installation of package ‘arrow’ failed
```

It seems to need to add `installation of package .* failed` pattern.