### PR TITLE
Example robust to NULL osVersion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-11-01  Michael Chirico  <chiricom@google.com>
+
+	* inst/examples/installRub.r: handle "bizarre" (`?osVersion`)
+	case where `utils::osVersion` is `NULL`.
+
 2024-08-28  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/examples/kitten.r: Use package 'whoami' if available for

--- a/inst/examples/installRub.r
+++ b/inst/examples/installRub.r
@@ -53,7 +53,7 @@ See https://dirk.eddelbuettel.com/code/littler.html for more information.\n")
 
 if (getRversion() < "4.2.0") stop("R version 4.2.0 or later is required.", call. = FALSE)
 if (!exists("osVersion")) stop("Cannot find 'osVersion'. Weird.", call. = FALSE)
-if (!startsWith(utils::osVersion, "Ubuntu")) stop("Ubuntu is required as host system.", call. = FALSE)
+if (!isTRUE(startsWith(utils::osVersion, "Ubuntu"))) stop("Ubuntu is required as host system.", call. = FALSE)
 has_bspm <- requireNamespace("bspm", quietly=TRUE)
 if (!opt$minimal && !has_bspm) stop("The 'bspm' package is required.", call. = FALSE)
 


### PR DESCRIPTION
Recently ran into some packages having trouble with `utils::osVersion` being `NULL` (as is a documented possibility).

Now I am searching around GitHub a bit to see if I can't improve robustness in some other places too.

That led me to this change: if `osVersion` is `NULL`, `startsWith()` will return `logical()` and trip up `if()`. `isTRUE()` as done here is the simplest fix.

 - This is the only usage of `osVersion` in the package
 - I also note just above the condition `exists("osVersion")`. As `osVersion` was introduced in R 3.5.0, it wouldn't be so "weird" for it to be absent there 😉. I am not sure if you care about this dotted-dotted-line implicit R version dependency.