### PR TITLE
Make script path available to R

### DIFF
--- a/src/littler.c
+++ b/src/littler.c
@@ -738,6 +738,8 @@ int main(int argc, char **argv){
         exit_val = parse_eval(&pb, evalstr, 1, verbose);
         destroy_membuf(pb);
     } else if (optind < argc && (strcmp(argv[optind],"-") != 0)) {
+        /* set environment variable giving path to script file */
+        setenv("LITTLER_SCRIPT_PATH", argv[optind], 1);
         /* call R function source(filename) */
         exit_val = source(argv[optind]);
     } else {


### PR DESCRIPTION
It can be helpful to know the path to the script being executed via a shebang line. This can be determined using `Rscript` via the `--file=` argument, although it's a little clunky:

```
$ cat Rscript.R
#! /usr/bin/env Rscript
print(commandArgs(FALSE))

$ ./Rscript.R
[1] "/opt/homebrew/Cellar/r/4.4.2_1/lib/R/bin/exec/R"
[2] "--no-echo"                                      
[3] "--no-restore"                                   
[4] "--file=./Rscript.R"
```

But, as far as I can tell from the source and some experimentation, `r` doesn't pass this information through `argv`, `commandArgs()` or the environment. This is a simple patch to set an environment variable containing the path, which should be unconditionally available by this point in the execution. The script path is then readily available:

```
$ cat littler.r 
#! /usr/bin/env lr
print(argv)
print(commandArgs(FALSE))
print(Sys.getenv("LITTLER_SCRIPT_PATH"))

$ ./littler.r 
NULL
[1] "littler"       "--gui=none"    "--no-restore"  "--no-save"    
[5] "--no-readline" "--silent"      "--slave"      
[1] "./littler.r"
```

I'm happy to change the name of the variable or refactor if there's a better way to do this (or be told that there is already a mechanism for it!), but since it's a small addition I thought I'd just propose something.