### PR TITLE
Clean up macOS debug symbol directory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-02-11  Jon Clayden  <code@clayden.org>
+
+	* cleanup: Clean up macOS debug symbol directory
+
 2025-01-22  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Date, Version): Roll micro version and date

--- a/cleanup
+++ b/cleanup
@@ -7,4 +7,4 @@ rm -f  aclocal.m4 \
        src/autoloads.h src/ldflags.txt src/littler.h \
        src/r src/gitversion.h *~ *.o \
        stamp-h1
-rm -rf autom4te.cache .deps inst/bin/
+rm -rf autom4te.cache .deps inst/bin/ src/r.dSYM/


### PR DESCRIPTION
Small addition to `cleanup` script to remove debug symbol (dSYM) directory created on macOS. Without this the package directory is dirty after `R CMD INSTALL --clean .`.